### PR TITLE
fix: reformat the code block for python 

### DIFF
--- a/_extensions/cheat_sheet/_extension.yml
+++ b/_extensions/cheat_sheet/_extension.yml
@@ -51,3 +51,5 @@ contributes:
         - _static
       cache: false
       resource-path: ["_static"]
+      listings: true
+      sansfontoptions: ["sfdefault"]

--- a/_extensions/cheat_sheet/partials/title.tex
+++ b/_extensions/cheat_sheet/partials/title.tex
@@ -65,7 +65,7 @@
 \renewcommand{\section}{\@startsection{section}{1}{0mm}%
                                 {-1ex plus -.5ex minus -.2ex}%
                                 {0.5ex plus .2ex}%
-                                {\normalfont\Large\bfseries\includegraphics[height=\fontcharht\font`\S]{./_static/slash.png}\hspace{0.4em}}}
+                                {\normalfont\Large\bfseries\includegraphics[height=\fontcharht\font`\S]{./_static/slash.png}\hspace{0.3em}}}
 % \makeatother
 \definecolor{silver}{RGB}{217,216,214}
 \definecolor{gold}{RGB}{255,183,27}
@@ -111,7 +111,3 @@
 
 \setlength{\parindent}{2pt}
 \setlength{\parskip}{1pt plus 0.5ex}
-
-% My Environments
-\newtheorem{example}[section]{Example}
-% -----------------------------------------------------------------------

--- a/_extensions/cheat_sheet/partials/title.tex
+++ b/_extensions/cheat_sheet/partials/title.tex
@@ -89,39 +89,25 @@
 \definecolor{codepurple}{rgb}{0.58,0,0.82}
 \definecolor{blue}{RGB}{57,114,161}
 \definecolor{black}{RGB}{0,0,0}
-\usepackage{framed}
 \definecolor{shadecolor}{RGB}{217,216,214} % Set the desired background color
 % renew if shaded is there
-\ifdefined\Shaded
-\renewenvironment{Shaded}{
-  \def\FrameCommand{{\color{shadecolor}\vrule width 1pt}\colorbox{shadecolor}} % Adjust frame properties
-  \MakeFramed{\advance\hsize-\width \FrameRestore \normalfont}}%
-{\endMakeFramed}
-\renewcommand{\CommentTok}[1]{\textcolor{codegreen}{#1}}
-\renewcommand{\CommentVarTok}[1]{\textcolor{magenta}{\textit{#1}}}
-\renewcommand{\ImportTok}[1]{\textcolor{magenta}{#1}}
-\renewcommand{\InformationTok}[1]{\textcolor[rgb]{0.37,0.37,0.37}{#1}}
-\renewcommand{\KeywordTok}[1]{\textcolor{codepurple}{#1}}
-\renewcommand{\NormalTok}[1]{\textcolor{black}{#1}}
-\fi
 \lstdefinestyle{python_style}{
-	backgroundcolor=\color{silver},
-	commentstyle=\color{codegreen},
-	keywordstyle=\color{magenta},
-	numberstyle=\tiny\color{codegray},
-	stringstyle=\color{codepurple},
-	frame=single,
-	basicstyle=\ttfamily\scale=0.95,
-	showstringspaces=false,
-  	breaklines=true,
-  	rulecolor=\color{black},
-  	captionpos=b,
-	% fontfamily=SourceCodePro-TLF,
-  	%aboveskip=10pt,
-  	%belowskip=10pt,
-  	inputencoding=utf8,
-  	extendedchars=true
-	%tabsize=2
+    backgroundcolor=\color{shadecolor}, % Set the background color
+    commentstyle=\color{codegreen}, % Style for comments
+    keywordstyle=\color{magenta}, % Style for keywords
+    numberstyle=\tiny\color{codegray}, % Style for line numbers
+    stringstyle=\color{codepurple}, % Style for strings
+    breaklines=true, % Enable line breaking
+    breakatwhitespace=true, % Break lines at whitespace
+    % linewidth=\textwidth, % Set the width of the code block to match the text width
+	basicstyle=\ttfamily\footnotesize, % Set the font style
+    frame=single, % Add a frame around the code
+    framesep=1pt, % Padding between the frame and the code
+    xleftmargin=1pt, % Left margin for the code block (adjust as needed)
+	rulecolor=\color{shadecolor},
+    % xrightmargin=15pt, % Right margin for the code block (adjust as needed)
+    showstringspaces=false, % Don't show spaces as special characters
+	tabsize=1,
 }
 \lstset{style=python_style, upquote=true}
 
@@ -134,33 +120,9 @@
 % Don't print section numbers
 \setcounter{secnumdepth}{0}
 
-
-\setlength{\parindent}{0pt}
-\setlength{\parskip}{0pt plus 0.5ex}
+\setlength{\parindent}{2pt}
+\setlength{\parskip}{1pt plus 0.5ex}
 
 % My Environments
 \newtheorem{example}[section]{Example}
 % -----------------------------------------------------------------------
-
-% Define custom style for Python code
-\lstdefinestyle{pythoncode}{
-	language=Python,
-	backgroundcolor=\color{red},
-	commentstyle=\color{codegreen},
-	keywordstyle=\color{magenta},
-	numberstyle=\tiny\color{codegray},
-	stringstyle=\color{codepurple},
-	frame=single,
-	basicstyle=\ttfamily\scale=0.95,
-	showstringspaces=false,
-  	breaklines=true,
-  	rulecolor=\color{black},
-  	captionpos=b,
-  	inputencoding=utf8,
-  	extendedchars=true
-}
-
-% Define the \pythoncode command
-\newcommand{\pythoncode}[2][]{%
-    \lstinputlisting[style=pythoncode, #1]{#2}%
-}

--- a/_extensions/cheat_sheet/partials/title.tex
+++ b/_extensions/cheat_sheet/partials/title.tex
@@ -27,7 +27,6 @@
 \usepackage{wrapfig}
 \usepackage{eso-pic}
 %add a monospace font
-\usepackage{inconsolata}
 %\usepackage[defaultfam,tabular,lining]{montserrat}
 \usepackage{float}
 \usepackage{tabularx}
@@ -44,8 +43,6 @@
 %\usepackage[scale=0.95]{sourcecodepro}
 %\usepackage{ragged2e}
 %\usepackage[dvipsnames]{xcolor}
-% \ProvidesPackage{pythonhighlight}[2011/09/19 python code highlighting; provided by Olivier Verdier <olivier.verdier@gmail.com>]
-%Path relative to the main .tex file
 
 % This sets page margins to .5 inch if using letter paper, and to 1cm
 % if using A4 paper. (This probably isn't strictly necessary.)
@@ -68,15 +65,7 @@
 \renewcommand{\section}{\@startsection{section}{1}{0mm}%
                                 {-1ex plus -.5ex minus -.2ex}%
                                 {0.5ex plus .2ex}%
-                                {\normalfont\Large\bfseries\includegraphics[height=\fontcharht\font`\S]{./_static/slash.png}\hspace{0.3em}}}
-% \renewcommand{\subsection}{\@startsection{subsection}{2}{0mm}%
-%                                 {-1explus -.5ex minus -.2ex}%
-%                                 {0.6ex plus .6ex}%
-%                                 {\normalfont\normalsize\bfseries}}
-% \renewcommand{\subsubsection}{\@startsection{subsubsection}{3}{0mm}%
-%                                 {-1ex plus -.5ex minus -.2ex}%
-%                                 {1ex plus .2ex}%
-%                                 {\normalfont\small\bfseries}}
+                                {\normalfont\Large\bfseries\includegraphics[height=\fontcharht\font`\S]{./_static/slash.png}\hspace{0.4em}}}
 % \makeatother
 \definecolor{silver}{RGB}{217,216,214}
 \definecolor{gold}{RGB}{255,183,27}

--- a/_extensions/cheat_sheet/partials/title.tex
+++ b/_extensions/cheat_sheet/partials/title.tex
@@ -44,14 +44,14 @@
 %\usepackage[scale=0.95]{sourcecodepro}
 %\usepackage{ragged2e}
 %\usepackage[dvipsnames]{xcolor}
-\ProvidesPackage{pythonhighlight}[2011/09/19 python code highlighting; provided by Olivier Verdier <olivier.verdier@gmail.com>]
+% \ProvidesPackage{pythonhighlight}[2011/09/19 python code highlighting; provided by Olivier Verdier <olivier.verdier@gmail.com>]
 %Path relative to the main .tex file
 
 % This sets page margins to .5 inch if using letter paper, and to 1cm
 % if using A4 paper. (This probably isn't strictly necessary.)
 % If using another size paper, use default 1cm margins.
 \ifthenelse{\lengthtest { \paperwidth = 11in}}
-    { \geometry{top=.15in,left=.25in,right=.25in,bottom=.1in} }
+    { \geometry{top=.15in,left=.25in,right=.25in,bottom=.15in} }
     {\ifthenelse{ \lengthtest{ \paperwidth = 297mm}}
         {\geometry{top=1cm,left=1cm,right=1cm,bottom=1cm} }
         {\geometry{top=1cm,left=1cm,right=1cm,bottom=1cm} }
@@ -68,16 +68,16 @@
 \renewcommand{\section}{\@startsection{section}{1}{0mm}%
                                 {-1ex plus -.5ex minus -.2ex}%
                                 {0.5ex plus .2ex}%
-                                {\normalfont\large\bfseries\includegraphics[height=\fontcharht\font`\S]{./_static/slash.png}\hspace{0.3em}}}
-\renewcommand{\subsection}{\@startsection{subsection}{2}{0mm}%
-                                {-1explus -.5ex minus -.2ex}%
-                                {0.6ex plus .6ex}%
-                                {\normalfont\normalsize\bfseries}}
-\renewcommand{\subsubsection}{\@startsection{subsubsection}{3}{0mm}%
-                                {-1ex plus -.5ex minus -.2ex}%
-                                {1ex plus .2ex}%
-                                {\normalfont\small\bfseries}}
-\makeatother
+                                {\normalfont\Large\bfseries\includegraphics[height=\fontcharht\font`\S]{./_static/slash.png}\hspace{0.3em}}}
+% \renewcommand{\subsection}{\@startsection{subsection}{2}{0mm}%
+%                                 {-1explus -.5ex minus -.2ex}%
+%                                 {0.6ex plus .6ex}%
+%                                 {\normalfont\normalsize\bfseries}}
+% \renewcommand{\subsubsection}{\@startsection{subsubsection}{3}{0mm}%
+%                                 {-1ex plus -.5ex minus -.2ex}%
+%                                 {1ex plus .2ex}%
+%                                 {\normalfont\small\bfseries}}
+% \makeatother
 \definecolor{silver}{RGB}{217,216,214}
 \definecolor{gold}{RGB}{255,183,27}
 \definecolor{steel}{RGB}{137,138,141}

--- a/examples/pymapdl_cheat_sheet_example.qmd
+++ b/examples/pymapdl_cheat_sheet_example.qmd
@@ -1,6 +1,6 @@
 ---
 title: PyMAPDL cheat sheet
-format: cheatsheet-pdf
+format: cheat_sheet-pdf
 version: 0.1.0
 footer: Getting started with PyMAPDL
 footerlinks:


### PR DESCRIPTION
### PR Description

This PR aims to enhance the LaTeX rendering within code cells by utilizing the `listing` package. The primary purpose of this update is to ensure that longer code snippets do not overflow or disrupt the formatting within Quarto documents.

#### Key Changes:
1. **LaTeX Listing Package Integration**:
    - Integrated the `listing` package to handle long code snippets.
    - ![image](https://github.com/user-attachments/assets/02408cb9-4a51-433e-8b42-ebdb76bb8719)

2. **Removal of Existing LaTeX Code**:
    - Removed any redundant LaTeX code that was previously implemented for handling the subsection and monospace