### PR TITLE
maint: using python 3.13 in CICD

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  MAIN_PYTHON_VERSION: '3.11'
+  MAIN_PYTHON_VERSION: '3.13'
   DOCUMENTATION_CNAME: 'quarto-cheat-sheet.docs.pyansys.com'
 
 concurrency:


### PR DESCRIPTION
This PR aims to check that ``pyansys-quarto-cheatsheet`` is compatible with Python 3.13.